### PR TITLE
AAAD-88 Add local notifications support

### DIFF
--- a/src/pages/FeedPage/Feed.tsx
+++ b/src/pages/FeedPage/Feed.tsx
@@ -12,6 +12,25 @@ import { useHidingHeader } from '../../hooks/useHidingHeader';
 import { useStores } from '../../stores/RootStore';
 import './Feed.css';
 
+// adding local notification for daily reminder to check newly published assignments and deadlines for existing ones
+import { Capacitor } from '@capacitor/core';
+ 
+declare var cordova: any; // stop TypeScript complaining.
+
+var smallIcon: "res://notification-logo";
+var d = new Date();
+var hours = d.getHours();
+var mins = d.getMinutes();
+ 
+cordova.plugins.notification.local.schedule({
+  id: 1,
+  smallIcon: smallIcon,
+  title: "Your daily art class reminder",
+  text: "Check your classes for new assignments and deadlines for existing assignments!",
+  trigger: { every: { hour: 10, minute: 30 }, count: 365 },
+  foreground: true
+}); 
+
 const FeedView: React.FC = () => {
   const [hideDecimal, setScrollYCurrent] = useHidingHeader(200)
 


### PR DESCRIPTION
In order for the Android project to build, the old support library references need replacing. This is the sequence of stuff I did:

Run these in commands in the terminal:

npm install https://github.com/Steffaan/cordova-plugin-local-notifications.git
npm install cordova-plugin-badge
npm install cordova-plugin-device
npm install jetifier
npx cap sync
npx jetify
npx cap copy
npx cap open android